### PR TITLE
Link the historical BMOPF baseline and v0.2.0 proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A draft description of the mathematical model is available in the root of this r
 The canonical home of the data schema is [`dsopt-schema`](https://github.com/distribution-system-opt/dsopt-schema), and the canonical home of the data semantics and math model is [`math-and-data-model-specifications`](https://github.com/distribution-system-opt/math-and-data-model-specifications). This repository holds draft and workshop material only. The copy at `draft_schema_and_networks/draft_bmopf_schema.json` is kept for the example networks beside it and is not the schema to write a case against.
 
 The [BMOPF 0.2.0 proposal](https://github.com/distribution-system-opt/dsopt-schema/tree/propose-bmopf-0.2.0)
-includes current examples, compatibility checks and integration work being prepared
-for PowerIO v0.11.0. It remains subject to Task Force review. Historical workshop
+builds on the Task Force's schema and specification work, with additional findings
+from a reference implementation in PowerIO v0.11.0. It remains subject to Task Force approval. Historical workshop
 files in this repository retain their original status and content.
 
 Community-based recommendations and contributions are welcome and encouraged. Please feel free to submit comments and questions in the [issue tracker](https://github.com/distribution-system-opt/bmopf-resources/issues).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ A draft description of the mathematical model is available in the root of this r
 
 The canonical home of the data schema is [`dsopt-schema`](https://github.com/distribution-system-opt/dsopt-schema), and the canonical home of the data semantics and math model is [`math-and-data-model-specifications`](https://github.com/distribution-system-opt/math-and-data-model-specifications). This repository holds draft and workshop material only. The copy at `draft_schema_and_networks/draft_bmopf_schema.json` is kept for the example networks beside it and is not the schema to write a case against.
 
+The [BMOPF 0.2.0 proposal](https://github.com/distribution-system-opt/dsopt-schema/tree/propose-bmopf-0.2.0)
+includes current examples, compatibility checks and integration work being prepared
+for PowerIO v0.11.0. It remains subject to Task Force review. Historical workshop
+files in this repository retain their original status and content.
+
 Community-based recommendations and contributions are welcome and encouraged. Please feel free to submit comments and questions in the [issue tracker](https://github.com/distribution-system-opt/bmopf-resources/issues).
 
 ## Upcoming Task Force activities


### PR DESCRIPTION
## Summary

Help workshop readers distinguish the historical v0.1.0 schema import from the proposed v0.2.0 extensions and find the ongoing Task Force review.

## Changes

- Link [schema baseline #3](https://github.com/distribution-system-opt/dsopt-schema/pull/3), [proposal #2](https://github.com/distribution-system-opt/dsopt-schema/pull/2), and [specification supplement #39](https://github.com/distribution-system-opt/math-and-data-model-specifications/pull/39).
- Explain that the historical resources schema remains the import's source until review and that a branch link does not establish release or ratification.
- Connect source, contributor, and review records, including the existing source/objective and price discussions.

This is an editorial link/status update. Historical schema bytes, network examples, workshop files, and their licences remain unchanged.

## Dependencies and validation

Base: `main`. Links target the open baseline/proposal branches and PRs, so they are usable during review. Baseline #3 precedes schema #2; the supplement remains based on Matt's [#36](https://github.com/distribution-system-opt/math-and-data-model-specifications/pull/36). This PR does not modify or close resources #21.

`git diff --check` passes. The diff is limited to the two README files, and the schema and historical examples match their previous contents.

## Contributions and precedent

The linked baseline credits **Matt Deakin** for initial schema and alignment work, **Frederik Geth** for schema development and review-driven changes, and **Samuel Talkington** for the port and versioned import. The proposal record separately credits the broader documentation, workshop, review, and integration contributions.

**Samuel Talkington** prepared this navigation update. Links to others' work acknowledge its authorship without implying that they co-authored or endorsed this link-only change. Feedback on the status wording and discoverability is welcome.
